### PR TITLE
[윤혁] 1주차 2단계 문자열계산기 

### DIFF
--- a/src/main/kotlin/step2/Operand.kt
+++ b/src/main/kotlin/step2/Operand.kt
@@ -1,0 +1,25 @@
+package step2
+
+data class Operand(private val value: Double) {
+
+    fun add(input: Operand) = Operand(this.value + input.value)
+
+    fun minus(input: Operand) = Operand(this.value - input.value)
+
+    fun multiply(input: Operand) = Operand(this.value * input.value)
+
+    fun divide(input: Operand): Operand {
+        validateInputIsNotZero(input)
+        return Operand(this.value / input.value)
+    }
+
+    private fun validateInputIsNotZero(input: Operand) {
+        if (input.value == 0.0) {
+            throw IllegalArgumentException("0으로는 나눌 수 없습니다.")
+        }
+    }
+
+    override fun toString(): String {
+        return "$value"
+    }
+}

--- a/src/main/kotlin/step2/Operator.kt
+++ b/src/main/kotlin/step2/Operator.kt
@@ -1,15 +1,16 @@
 package step2
 
-typealias CalculateStrategy = (leftValue: Operand, rightValue: Operand) -> Operand
-
-enum class Operator(private val symbol: String, private val strategy: CalculateStrategy) {
+enum class Operator(
+    private val symbol: String,
+    private val calculateStrategy: (leftValue: Operand, rightValue: Operand) -> Operand
+) {
     ADD("+", Operand::add),
     MINUS("-", Operand::minus),
     MULTIPLY("*", Operand::multiply),
     DIVIDE("/", Operand::divide);
 
     fun calculate(leftValue: Operand, rightValue: Operand): Operand {
-        return strategy.invoke(leftValue, rightValue)
+        return calculateStrategy.invoke(leftValue, rightValue)
     }
 
     companion object {

--- a/src/main/kotlin/step2/Operator.kt
+++ b/src/main/kotlin/step2/Operator.kt
@@ -1,0 +1,21 @@
+package step2
+
+typealias CalculateStrategy = (leftValue: Operand, rightValue: Operand) -> Operand
+
+enum class Operator(private val symbol: String, private val strategy: CalculateStrategy) {
+    ADD("+", Operand::add),
+    MINUS("-", Operand::minus),
+    MULTIPLY("*", Operand::multiply),
+    DIVIDE("/", Operand::divide);
+
+    fun calculate(leftValue: Operand, rightValue: Operand): Operand {
+        return strategy.invoke(leftValue, rightValue)
+    }
+
+    companion object {
+        fun findBySymbol(symbol: String): Operator {
+            return values().find { operator -> operator.symbol == symbol }
+                ?: throw IllegalArgumentException("$symbol 기호에 해당하는 연산은 존재하지 않습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/step2/StringCalculator.kt
+++ b/src/main/kotlin/step2/StringCalculator.kt
@@ -7,6 +7,7 @@ class StringCalculator {
         private const val INDEX_OF_OPERAND = 1
 
         fun calculate(splitValues: List<String>): Operand {
+            validateNotEmptyString(splitValues)
             var result = Operand(splitValues[0].toDouble())
             for (i in 1 until splitValues.size step 2) {
                 val operator = Operator.findBySymbol(splitValues[INDEX_OF_OPERATOR + i])
@@ -14,6 +15,11 @@ class StringCalculator {
                 result = operator.calculate(result, operand)
             }
             return result
+        }
+
+        private fun validateNotEmptyString(splitValues: List<String>) {
+            splitValues.find { it.isBlank() }
+                ?.run { throw IllegalArgumentException("입력 문자는 공백 일 수 없습니다.") }
         }
     }
 }

--- a/src/main/kotlin/step2/StringCalculator.kt
+++ b/src/main/kotlin/step2/StringCalculator.kt
@@ -7,13 +7,13 @@ class StringCalculator {
         private const val INDEX_OF_OPERAND = 1
 
         fun calculate(splitValues: List<String>): Operand {
-            var firstValue = Operand(splitValues[0].toDouble())
+            var result = Operand(splitValues[0].toDouble())
             for (i in 1 until splitValues.size step 2) {
                 val operator = Operator.findBySymbol(splitValues[INDEX_OF_OPERATOR + i])
                 val operand = Operand(splitValues[INDEX_OF_OPERAND + i].toDouble())
-                firstValue = operator.calculate(firstValue, operand)
+                result = operator.calculate(result, operand)
             }
-            return firstValue
+            return result
         }
     }
 }

--- a/src/main/kotlin/step2/StringCalculator.kt
+++ b/src/main/kotlin/step2/StringCalculator.kt
@@ -1,0 +1,19 @@
+package step2
+
+class StringCalculator {
+
+    companion object {
+        private const val INDEX_OF_OPERATOR = 0
+        private const val INDEX_OF_OPERAND = 1
+
+        fun calculate(splitValues: List<String>): Operand {
+            var firstValue = Operand(splitValues[0].toDouble())
+            for (i in 1 until splitValues.size step 2) {
+                val operator = Operator.findBySymbol(splitValues[INDEX_OF_OPERATOR + i])
+                val operand = Operand(splitValues[INDEX_OF_OPERAND + i].toDouble())
+                firstValue = operator.calculate(firstValue, operand)
+            }
+            return firstValue
+        }
+    }
+}

--- a/src/main/kotlin/step2/StringCalculatorApplication.kt
+++ b/src/main/kotlin/step2/StringCalculatorApplication.kt
@@ -1,0 +1,10 @@
+package step2
+
+import step2.view.getSplitStringForCalculate
+import step2.view.printInsertStringForCalculate
+
+fun main() {
+    printInsertStringForCalculate()
+    val symbols = getSplitStringForCalculate()
+    println(StringCalculator.calculate(symbols))
+}

--- a/src/main/kotlin/step2/view/InputView.kt
+++ b/src/main/kotlin/step2/view/InputView.kt
@@ -1,0 +1,3 @@
+package step2.view
+
+fun getSplitStringForCalculate() = readLine()!!.split(" ")

--- a/src/main/kotlin/step2/view/InputView.kt
+++ b/src/main/kotlin/step2/view/InputView.kt
@@ -1,3 +1,4 @@
 package step2.view
 
-fun getSplitStringForCalculate() = readLine()!!.split(" ")
+fun getSplitStringForCalculate() = readLine()?.split(" ")
+    ?: throw IllegalArgumentException("읽은 문자열은 null 일 수 없음.")

--- a/src/main/kotlin/step2/view/OutputView.kt
+++ b/src/main/kotlin/step2/view/OutputView.kt
@@ -1,0 +1,3 @@
+package step2.view
+
+fun printInsertStringForCalculate() = println("사칙연산 문자열을 입력해주세요 (띄어쓰기로 구분)")

--- a/src/test/kotlin/step2/OperandTest.kt
+++ b/src/test/kotlin/step2/OperandTest.kt
@@ -1,0 +1,60 @@
+package step2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class OperandTest {
+
+    @Test
+    fun `덧셈 결과 테스트`() {
+        // given
+        val operand1 = Operand(1.0)
+        val operand2 = Operand(2.0)
+
+        // then
+        assertThat(operand1.add(operand2)).isEqualTo(Operand(3.0))
+    }
+
+    @Test
+    fun `뺄셈 결과 테스트`() {
+        // given
+        val operand1 = Operand(2.0)
+        val operand2 = Operand(1.0)
+
+        // then
+        assertThat(operand1.minus(operand2)).isEqualTo(Operand(1.0))
+    }
+
+    @Test
+    fun `곱셈 결과 테스트`() {
+        // given
+        val operand1 = Operand(3.0)
+        val operand2 = Operand(2.0)
+
+        // then
+        assertThat(operand1.multiply(operand2)).isEqualTo(Operand(6.0))
+    }
+
+    @Test
+    fun `나눗셈 결과 테스트`() {
+        // given
+        val operand1 = Operand(4.0)
+        val operand2 = Operand(2.0)
+
+        // then
+        assertThat(operand1.divide(operand2)).isEqualTo(Operand(2.0))
+    }
+
+    @Test
+    fun `0으로 나눌 시 Exception`() {
+        // given
+        val operand1 = Operand(4.0)
+        val operand2 = Operand(0.0)
+
+        // then
+        assertThatThrownBy { operand1.divide(operand2) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("0으로는 나눌 수 없습니다.")
+    }
+}

--- a/src/test/kotlin/step2/OperatorTest.kt
+++ b/src/test/kotlin/step2/OperatorTest.kt
@@ -1,0 +1,39 @@
+package step2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class OperatorTest {
+
+    @CsvSource("+,ADD", "-,MINUS", "*,MULTIPLY", "/,DIVIDE")
+    @ParameterizedTest
+    fun `유효한 연산 기호 찾는지 확인`(symbol: String, operator: Operator) {
+        // then
+        assertThat(Operator.findBySymbol(symbol)).isEqualTo(operator)
+    }
+
+    @Test
+    fun `유효하지 않은 연산 기호 넣을 시 Exception`() {
+        // then
+        assertThatThrownBy { Operator.findBySymbol("!") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("! 기호에 해당하는 연산은 존재하지 않습니다.")
+    }
+
+    @CsvSource("1,2,ADD,3", "3,1,MINUS,2", "2,4,MULTIPLY,8", "12,3,DIVIDE,4")
+    @ParameterizedTest
+    fun `계산 전략에 따른 계산 결과 확인`(value1: Double, value2: Double, operator: Operator, result: Double) {
+        // given
+        val operand1 = Operand(value1)
+        val operand2 = Operand(value2)
+
+        // when
+        val expectedOperand = operator.calculate(operand1, operand2)
+
+        // then
+        assertThat(expectedOperand).isEqualTo(Operand(result))
+    }
+}

--- a/src/test/kotlin/step2/StringCalculatorTest.kt
+++ b/src/test/kotlin/step2/StringCalculatorTest.kt
@@ -1,6 +1,7 @@
 package step2
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
 class StringCalculatorTest {
@@ -12,5 +13,16 @@ class StringCalculatorTest {
         // then
         assertThat(StringCalculator.calculate(splitString))
             .isEqualTo(Operand(10.0))
+    }
+
+    @Test
+    fun `공백문자 넣을 시 Exception`() {
+        // given
+        val splitString = " ".split(" ")
+
+        // then
+        assertThatThrownBy { StringCalculator.calculate(splitString) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("입력 문자는 공백 일 수 없습니다.")
     }
 }

--- a/src/test/kotlin/step2/StringCalculatorTest.kt
+++ b/src/test/kotlin/step2/StringCalculatorTest.kt
@@ -1,0 +1,16 @@
+package step2
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class StringCalculatorTest {
+    @Test
+    fun `유효한 문자열 넣을 시 결과 확인`() {
+        // given
+        val splitString = "2 + 3 * 4 / 2".split(" ")
+
+        // then
+        assertThat(StringCalculator.calculate(splitString))
+            .isEqualTo(Operand(10.0))
+    }
+}


### PR DESCRIPTION
미션 제출합니다.

궁금한건 Java에서는 한 메소드만을 지닌 interface를 람다로 바로 쓸 수 있고, 코틀린에서는 SAM이라는걸 통해서 람다로 쓸 수 있게 변환해준다고 들었습니다. 코틀린 1.4이상부터는 interface도 람다로 쓸 수 있다고 들었는데, 그 이전에는 불가능한건지도 궁금합니다.
코틀린에서 interface로 선언한 것을 람다로 쓸 수 없어 Operator의 프로퍼티로 람다를 갖게 했습니다. 가독성을 위해 typealias 키워드를 사용했습니다.
override코드를 쓰고 싶지 않고 한 줄로 해결하고싶어 위 방법대로 했으나, 어떤 방법이 더 나은방법인지 잘 모르겠습니다.
