### PR TITLE
[Step5] 자동차 경주(리팩터링)

### DIFF
--- a/src/main/kotlin/racingcar/domain/Car.kt
+++ b/src/main/kotlin/racingcar/domain/Car.kt
@@ -4,6 +4,14 @@ class Car(val userName: String) {
     var position: Int = 0
         private set
 
+    init {
+        require(userName.length < UPPER_USERNAME_SIZE) { "자동차 이름은 ${UPPER_USERNAME_SIZE}자를 초과할 수 없습니다." }
+    }
+
+    companion object {
+        const val UPPER_USERNAME_SIZE = 5
+    }
+
     fun tryMove(conditionNumber: Int) {
         if (CarConfig.MOVE_PERCENTAGE <= conditionNumber) {
             position++

--- a/src/main/kotlin/racingcar/domain/CarCollection.kt
+++ b/src/main/kotlin/racingcar/domain/CarCollection.kt
@@ -1,19 +1,13 @@
 package racingcar.domain
 
-import racingcar.history.RacingResultHistory
-
 class CarCollection(userNames: List<String>) {
 
-    private val cars: List<Car> = userNames.map { Car(it) }
-    private val racingResultHistory = RacingResultHistory()
+    val cars: List<Car> = userNames.map { Car(it) }
 
-    fun tryMoveCars(round: Int, conditionNumbers: List<Int>) {
+    fun tryMoveCars(conditionNumbers: List<Int>) {
         cars.zip(conditionNumbers)
             .forEach { (car, number) -> car.tryMove(number) }
-        racingResultHistory.logging(round, cars = cars)
     }
-
-    fun getRacingHistories() = racingResultHistory.getResults()
 
     fun size(): Int = cars.size
 

--- a/src/main/kotlin/racingcar/domain/RacingGame.kt
+++ b/src/main/kotlin/racingcar/domain/RacingGame.kt
@@ -1,18 +1,21 @@
 package racingcar.domain
 
 import racingcar.domain.CarConfig.randomNumberGenerator
+import racingcar.history.RacingResultHistory
 import racingcar.history.RacingRoundHistory
 import racingcar.userInput.UserNameInfo
 
 class RacingGame(private val tryCount: Int, private val userNameInfo: UserNameInfo) {
 
     private val carCollection = CarCollection(userNameInfo.usernames)
+    private val racingResultHistory = RacingResultHistory()
 
     fun runRace(): List<RacingRoundHistory> {
         repeat(tryCount) {
-            carCollection.tryMoveCars(round = it, conditionNumbers = randomNumberGenerator(carCollection.size()))
+            carCollection.tryMoveCars(conditionNumbers = randomNumberGenerator(carCollection.size()))
+            racingResultHistory.logging(round = it, cars = carCollection.cars)
         }
-        return carCollection.getRacingHistories()
+        return racingResultHistory.getResults()
     }
 
     fun getWinner() = carCollection.getWinner()

--- a/src/test/kotlin/racingcar/domain/CarCollectionTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarCollectionTest.kt
@@ -11,25 +11,25 @@ internal class CarCollectionTest {
     @Test
     @DisplayName("기준 숫자인 4이상의 값과 매칭되는 차는 이동한다")
     fun tryMoveCars() {
-        val carCollection = CarCollection(listOf("jyami", "java", "spring"))
+        val carCollection = CarCollection(listOf("mj", "java", "kt"))
         carCollection.tryMoveCars(1, arrayListOf(0, 4, 8))
 
         val racingHistory = carCollection.getRacingHistories()[0].racingActionHistories
 
         assertThat(racingHistory).containsSequence(
-            RacingActionHistory(0, "jyami"),
+            RacingActionHistory(0, "mj"),
             RacingActionHistory(1, "java"),
-            RacingActionHistory(1, "spring")
+            RacingActionHistory(1, "kt")
         )
     }
 
     @Test
     @DisplayName("자동차의 이동 위치를 이용해 승자를 구한다.")
     fun getWinner() {
-        val carCollection = CarCollection(listOf("jyami", "java", "spring"))
+        val carCollection = CarCollection(listOf("mj", "java", "kt"))
         carCollection.tryMoveCars(1, arrayListOf(0, 10, 10))
         carCollection.tryMoveCars(1, arrayListOf(0, 10, 10))
 
-        assertThat(carCollection.getWinner().map { it.userName }).contains("java", "spring")
+        assertThat(carCollection.getWinner().map { it.userName }).contains("java", "kt")
     }
 }

--- a/src/test/kotlin/racingcar/domain/CarCollectionTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarCollectionTest.kt
@@ -4,7 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 import org.junit.jupiter.api.DisplayName
-import racingcar.history.RacingActionHistory
 
 internal class CarCollectionTest {
 
@@ -12,24 +11,16 @@ internal class CarCollectionTest {
     @DisplayName("기준 숫자인 4이상의 값과 매칭되는 차는 이동한다")
     fun tryMoveCars() {
         val carCollection = CarCollection(listOf("mj", "java", "kt"))
-        carCollection.tryMoveCars(1, arrayListOf(0, 4, 8))
-
-        val racingHistory = carCollection.getRacingHistories()[0].racingActionHistories
-
-        assertThat(racingHistory).containsSequence(
-            RacingActionHistory(0, "mj"),
-            RacingActionHistory(1, "java"),
-            RacingActionHistory(1, "kt")
-        )
+        carCollection.tryMoveCars(arrayListOf(0, 4, 8))
+        assertThat(carCollection.cars.map { it.userName }).containsSequence("mj", "java", "kt")
     }
 
     @Test
     @DisplayName("자동차의 이동 위치를 이용해 승자를 구한다.")
     fun getWinner() {
         val carCollection = CarCollection(listOf("mj", "java", "kt"))
-        carCollection.tryMoveCars(1, arrayListOf(0, 10, 10))
-        carCollection.tryMoveCars(1, arrayListOf(0, 10, 10))
-
+        carCollection.tryMoveCars(arrayListOf(0, 10, 10))
+        carCollection.tryMoveCars(arrayListOf(0, 10, 10))
         assertThat(carCollection.getWinner().map { it.userName }).contains("java", "kt")
     }
 }

--- a/src/test/kotlin/racingcar/domain/CarTest.kt
+++ b/src/test/kotlin/racingcar/domain/CarTest.kt
@@ -4,15 +4,25 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
+import java.lang.IllegalArgumentException
 
 internal class CarTest {
 
     @Test
     @DisplayName("랜덤으로 선정된 값이 기준 확률보다 커 자동차가 움직일 수 있다")
     fun tryMoveSuccess() {
-        val car = Car("jyami")
+        val car = Car("mj")
         car.tryMove(10)
         assertThat(car.position).isEqualTo(1)
-        assertThat(car.userName).isEqualTo("jyami")
+        assertThat(car.userName).isEqualTo("mj")
+    }
+
+    @Test
+    @DisplayName("자동차 이름은 5자를 초과할 수 없다.")
+    fun name() {
+        assertThrows<IllegalArgumentException> {
+            val car = Car("jyami")
+        }
     }
 }

--- a/src/test/kotlin/racingcar/domain/RacingGameTest.kt
+++ b/src/test/kotlin/racingcar/domain/RacingGameTest.kt
@@ -11,14 +11,14 @@ internal class RacingGameTest {
     @Test
     @DisplayName("레이싱 게임을 실행하면 수행 개수만큼의 이력이 남는다.")
     fun runRaceTryCount() {
-        val runRace = RacingGame(10, UserNameInfo("jyami,java,spring")).runRace()
+        val runRace = RacingGame(10, UserNameInfo("mj,java,kt")).runRace()
         assertThat(runRace.size).isEqualTo(10)
     }
 
     @Test
     @DisplayName("레이싱 게임을 실행하면 하나의 액션당 Car의 개수만큼의 이력이 남는다")
     fun runRaceNumberOfCar() {
-        val runRace = RacingGame(10, UserNameInfo("jyami,java,spring")).runRace()
+        val runRace = RacingGame(10, UserNameInfo("mj,java,kt")).runRace()
         assertThat(runRace[0].racingActionHistories.size).isEqualTo(3)
     }
 }

--- a/src/test/kotlin/racingcar/history/RacingActionHistoryTest.kt
+++ b/src/test/kotlin/racingcar/history/RacingActionHistoryTest.kt
@@ -11,7 +11,7 @@ internal class RacingActionHistoryTest {
     @Test
     @DisplayName("현재 차의 위치를 RacingAction 으로 저장한다.")
     fun getPosition() {
-        val car = Car("jyami")
+        val car = Car("mj")
 
         val action1 = RacingActionHistory.of(car)
         car.tryMove(10)
@@ -19,7 +19,7 @@ internal class RacingActionHistoryTest {
 
         assertThat(action1.position).isEqualTo(0)
         assertThat(action2.position).isEqualTo(1)
-        assertThat(action1.userName).isEqualTo("jyami")
-        assertThat(action2.userName).isEqualTo("jyami")
+        assertThat(action1.userName).isEqualTo("mj")
+        assertThat(action2.userName).isEqualTo("mj")
     }
 }

--- a/src/test/kotlin/racingcar/history/RacingResultHistoryTest.kt
+++ b/src/test/kotlin/racingcar/history/RacingResultHistoryTest.kt
@@ -12,7 +12,7 @@ internal class RacingResultHistoryTest {
     @DisplayName("자동차의 위치를 logging 하여 history를 저장한다.")
     fun logging() {
         val racingResultHistory = RacingResultHistory()
-        val car1 = Car("jyami")
+        val car1 = Car("mj")
         val car2 = Car("java")
         racingResultHistory.logging(1, listOf(car1, car2))
         car2.tryMove(10)
@@ -20,13 +20,13 @@ internal class RacingResultHistoryTest {
 
         assertThat(racingResultHistory.getResults()[0].racingActionHistories)
             .containsSequence(
-                RacingActionHistory(0, "jyami"),
+                RacingActionHistory(0, "mj"),
                 RacingActionHistory(0, "java")
             )
 
         assertThat(racingResultHistory.getResults()[1].racingActionHistories)
             .containsSequence(
-                RacingActionHistory(0, "jyami"),
+                RacingActionHistory(0, "mj"),
                 RacingActionHistory(1, "java")
             )
     }

--- a/src/test/kotlin/racingcar/history/RacingRoundHistoryTest.kt
+++ b/src/test/kotlin/racingcar/history/RacingRoundHistoryTest.kt
@@ -9,18 +9,18 @@ internal class RacingRoundHistoryTest {
     @Test
     @DisplayName("차들의 현재 위치를 기록한다")
     fun racingAction() {
-        val car1 = Car("jyami")
+        val car1 = Car("mj")
         val car2 = Car("java")
         val round1 = RacingRoundHistory.of(1, listOf(car1, car2))
         car1.tryMove(10)
         val round2 = RacingRoundHistory.of(2, listOf(car1, car2))
 
         assertThat(round1.racingActionHistories).containsSequence(
-            RacingActionHistory(0, "jyami"),
+            RacingActionHistory(0, "mj"),
             RacingActionHistory(0, "java")
         )
         assertThat(round2.racingActionHistories).containsSequence(
-            RacingActionHistory(1, "jyami"),
+            RacingActionHistory(1, "mj"),
             RacingActionHistory(0, "java")
         )
     }


### PR DESCRIPTION
- view 분리 : 기존에 완
- Random 테스트 : 기존에 완

질문 : 영현님이 주신 리뷰중에 tryMove의 역할이 너무 많다고 한 게 있었는데요. 동의하는 부분입니다. 그래서 기존에 CarCollection에 있던 history객체를 racingGame으로 옮겼는데, 이때 좀 문제가 생겼습니다. 
이렇게 하면 CarCollection에 있는 List<Car>를 getter를 파야하는데, 그렇게 되면 일급 컬렉션이 하는 역할을 하지 못하게 됩니다. 생각해보니 제가 이 문제때문에 CarCollection에 history객체를 넣었더라구요. 
혹시 조언 주실 수 있으실까요?