### PR TITLE
[STEP1] 문자열 덧셈 계산기 (week2)

### DIFF
--- a/src/main/kotlin/week2/calculator/StringAddCalculator.kt
+++ b/src/main/kotlin/week2/calculator/StringAddCalculator.kt
@@ -1,0 +1,32 @@
+package week2.calculator
+
+class StringAddCalculator {
+    private val delimiters = mutableListOf(",", ":") // default delimiters
+
+    fun add(text: String?): Int {
+        if (text.isNullOrBlank()) return 0
+        val inputs = parseInputs(text)
+        if (inputs.any { it.toInt() < 0 }) throw RuntimeException("Input must be non-negative")
+        return addByInputSize(inputs)
+    }
+
+    private fun parseInputs(text: String): List<String> {
+        var splitTarget = text
+        if (text.startsWith("//")) {
+            val delimiterAndInput = text.split("\n")
+            val customDelimiter = delimiterAndInput[0].removePrefix("//")
+            delimiters.add(customDelimiter)
+            splitTarget = delimiterAndInput[1]
+        }
+        return splitTarget.split(delimiters = delimiters.toTypedArray())
+    }
+
+    private fun addByInputSize(inputs: List<String>): Int {
+        assert(inputs.isNotEmpty())
+        return when (inputs.size) {
+            1 -> inputs[0].toInt()
+            2 -> inputs[0].toInt() + inputs[1].toInt()
+            else -> inputs[0].toInt() + inputs[1].toInt() + inputs[2].toInt()
+        }
+    }
+}

--- a/src/test/kotlin/week2/calculator/StringStringAddCalculatorTest.kt
+++ b/src/test/kotlin/week2/calculator/StringStringAddCalculatorTest.kt
@@ -1,0 +1,61 @@
+package week2.calculator
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullAndEmptySource
+import org.junit.jupiter.params.provider.ValueSource
+
+class StringStringAddCalculatorTest {
+    private lateinit var calculator: StringAddCalculator
+
+    @BeforeEach
+    fun setUp() {
+        calculator = StringAddCalculator();
+    }
+
+    @DisplayName(value = "빈 문자열 또는 null 값을 입력할 경우 0을 반환해야 한다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    fun emptyOrNull(text: String?) {
+        assertThat(calculator.add(text)).isZero()
+    }
+
+    @DisplayName(value = "숫자 하나를 문자열로 입력할 경우 해당 숫자를 반환한다.")
+    @ParameterizedTest
+    @ValueSource(strings = ["1"])
+    fun oneNumber(text: String) {
+        assertThat(calculator.add(text)).isSameAs(Integer.parseInt(text))
+    }
+
+    @DisplayName(value = "숫자 두개를 쉼표(,) 구분자로 입력할 경우 두 숫자의 합을 반환한다.")
+    @ParameterizedTest
+    @ValueSource(strings = ["1,2"])
+    fun twoNumbers(text: String) {
+        assertThat(calculator.add(text)).isSameAs(3)
+    }
+
+    @DisplayName(value = "구분자를 쉼표(,) 이외에 콜론(:)을 사용할 수 있다.")
+    @ParameterizedTest
+    @ValueSource(strings = ["1,2:3"])
+    fun colons(text: String) {
+        assertThat(calculator.add(text)).isSameAs(6)
+    }
+
+    @DisplayName(value = "//와 \\n 문자 사이에 커스텀 구분자를 지정할 수 있다.")
+    @ParameterizedTest
+    @ValueSource(strings = ["//;\n1;2;3"])
+    fun customDelimiter(text: String) {
+        assertThat(calculator.add(text)).isSameAs(6)
+    }
+
+    @DisplayName(value = "문자열 계산기에 음수를 전달하는 경우 RuntimeException 예외 처리를 한다.")
+    @Test
+    fun negative() {
+        assertThatExceptionOfType(RuntimeException::class.java)
+            .isThrownBy { calculator.add("-1") }
+    }
+}

--- a/src/test/kotlin/week2/calculator/StringStringAddCalculatorTest.kt
+++ b/src/test/kotlin/week2/calculator/StringStringAddCalculatorTest.kt
@@ -59,3 +59,4 @@ class StringStringAddCalculatorTest {
             .isThrownBy { calculator.add("-1") }
     }
 }
+


### PR DESCRIPTION
1단계 - 문자열 덧셈 계산기

기능 요구 사항
- 쉼표(,) 또는 콜론(:)을 구분자로 가지는 문자열을 전달하는 경우 구분자를 기준으로 분리한 각 숫자의 합을 반환 (예: “” => 0, "1,2" => 3, "1,2,3" => 6, “1,2:3” => 6)
- 앞의 기본 구분자(쉼표, 콜론) 외에 커스텀 구분자를 지정할 수 있다. 커스텀 구분자는 문자열 앞부분의 “//”와 “\n” 사이에 위치하는 문자를 커스텀 구분자로 사용한다. 예를 들어 “//;\n1;2;3”과 같이 값을 입력할 경우 커스텀 구분자는 세미콜론(;)이며, 결과 값은 6이 반환되어야 한다.
- 문자열 계산기에 숫자 이외의 값 또는 음수를 전달하는 경우 RuntimeException 예외를 throw 한다.
